### PR TITLE
feat: get provider from URL

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,17 @@
+export const providers = {
+  youtube: 'youtube',
+  vimeo: 'vimeo',
+  loom: 'loom',
+  codepen: 'codepen',
+  codesandbox: 'codesandbox',
+} as const;
+
+export const supported_urls = {
+  'youtu.be': 'youtu.be',
+  'm.youtube.com': 'm.youtube.com',
+};
+
+export const regexs = {
+  [providers.youtube]:
+    /^.*(?:(?:youtu\.be\/|v\/|vi\/|u\/\w\/|embed\/|shorts\/)|(?:(?:watch)?\?v(?:i)?=|&v(?:i)?=))([^#&?]*).*/,
+};

--- a/src/extract.ts
+++ b/src/extract.ts
@@ -1,0 +1,47 @@
+import { providers, regexs, supported_urls } from './constants.js';
+import type { Providers } from './global.types.js';
+import { extractHostname } from './utils.js';
+import validate from './validate.js';
+
+class Extract {
+  getProvider(link: string) {
+    const isValid = validate.check(link);
+    if (!isValid) return;
+
+    const url = new URL(link);
+    const hostname = extractHostname(url.hostname);
+
+    const provider = Object.values(providers).find((host) => hostname === host);
+
+    if (provider) {
+      return provider;
+    }
+
+    switch (true) {
+      case url.hostname.includes(supported_urls['youtu.be']):
+      case url.hostname.includes(supported_urls['m.youtube.com']):
+        return providers.youtube;
+
+      default:
+        throw new Error('URL not supported!');
+    }
+  }
+
+  getId({ link, provider }: { link: string; provider: Providers }) {
+    switch (provider) {
+      case providers.youtube: {
+        const parsed = link.match(regexs[providers.youtube]);
+
+        if (!parsed || !parsed[1]) {
+          throw new Error('Embed is not supported for this URL');
+        }
+        return parsed[1];
+      }
+
+      default:
+        return null;
+    }
+  }
+}
+
+export default Extract;

--- a/src/global.types.ts
+++ b/src/global.types.ts
@@ -1,0 +1,3 @@
+import type { providers } from './constants.js';
+
+export type Providers = (typeof providers)[keyof typeof providers];

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,43 @@
-import { add } from './utils.js';
+/**
+ * API Surface
+ *
+ * Main entry
+ * oembed.parse(link, options)
+ * - outpute { id, embedURL, iframe, link, provider }
+ *
+ * Shortcuts:
+ * oembed.getId(link)
+ * output: id
+ *
+ *
+ * oembed.getEmbedURL(link)
+ * output: embedURL
+ *
+ *
+ * oembed.getIframe(link)
+ * output: iframe
+ *
+ *
+ * oembed.getProvider(link)
+ * output: provider (eg.: youtube, vimeo, twitter)
+ */
+
+import Extract from './extract.js';
+
+class OEmbed {
+  #extracter = new Extract();
+
+  getProvider(link: string) {
+    return this.#extracter.getProvider(link);
+  }
+
+  getId(link: string) {
+    const provider = this.getProvider(link);
+    if (provider) {
+      return this.#extracter.getId({ link, provider });
+    }
+  }
+}
+
+const oembed = new OEmbed();
+export default oembed;

--- a/src/tests/extract.test.ts
+++ b/src/tests/extract.test.ts
@@ -1,0 +1,61 @@
+import { test, expect } from 'vitest';
+import Extract from '../extract.js';
+
+const extract = new Extract();
+
+test('getProvider: Unsupported URL', () => {
+  expect(() => extract.getProvider('https://gmail.com')).toThrow(
+    'URL not supported!',
+  );
+});
+
+test('getProvider: youtube.com', () => {
+  expect(
+    extract.getProvider('https://www.youtube.com/watch?v=-ELSsP9MDt0'),
+  ).toBe('youtube');
+});
+
+test('getProvider: youtu.be', () => {
+  expect(
+    extract.getProvider('https://youtu.be/-ELSsP9MDt0?si=On79Hs36qjSpWghn'),
+  ).toBe('youtube');
+});
+
+test('getProvider: m.youtube.com', () => {
+  expect(extract.getProvider('https://m.youtube.com/watch?v=lalOy8Mbfdc')).toBe(
+    'youtube',
+  );
+});
+
+test('getProvider: vimeo.com', () => {
+  expect(extract.getProvider('https://vimeo.com/76979871')).toBe('vimeo');
+});
+
+test('getProvider: loom.com', () => {
+  expect(
+    extract.getProvider(
+      'https://www.loom.com/embed/e5b8c04bca094dd8a5507925ab887002',
+    ),
+  ).toBe('loom');
+});
+
+test('getProvider: codepen.io', () => {
+  expect(
+    extract.getProvider('https://codepen.io/roniee_1993/pen/jEbaJBm'),
+  ).toBe('codepen');
+});
+
+test('getProvider: codesandbox.io', () => {
+  expect(
+    extract.getProvider('https://codesandbox.io/p/sandbox/react-new'),
+  ).toBe('codesandbox');
+});
+
+test('check: Empty Input', () => {
+  expect(
+    extract.getId({
+      link: 'https://www.youtube.com/watch?v=-ELSsP9MDt0',
+      provider: 'youtube',
+    }),
+  ).toBe('-ELSsP9MDt0');
+});

--- a/src/tests/utils.test.ts
+++ b/src/tests/utils.test.ts
@@ -1,6 +1,0 @@
-import { test, expect } from 'vitest';
-import { add } from '../utils.js';
-
-test('add', () => {
-  expect(add(1, 2)).toBe(3);
-});

--- a/src/tests/validate.test.ts
+++ b/src/tests/validate.test.ts
@@ -1,0 +1,11 @@
+import { test, expect } from 'vitest';
+import validate from '../validate.js';
+
+test('check: Empty Input', () => {
+  // @ts-ignore
+  expect(() => validate.check()).toThrow();
+});
+
+test('check: Invalid URL', () => {
+  expect(() => validate.check('random-test-string')).toThrow();
+});

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,1 +1,32 @@
-export const add = (a: number, b: number) => a + b;
+export const extractHostname = (hostname: string) => {
+  // Step 1: strip common prefixes
+  let cleaned = hostname.replace(/^(www\.|m\.)/, '');
+
+  // Step 2: split into parts
+  const parts = cleaned.split('.');
+
+  // Handle common cases like .com, .io, .co.uk etc.
+  if (parts.length > 2) {
+    // For domains like "subdomain.youtube.com" → "youtube"
+    return parts[parts.length - 2];
+  } else {
+    // For simple domains like "youtube.com" → "youtube"
+    return parts[0];
+  }
+};
+
+export const isEmpty = (link: string) => {
+  if (!link || !link?.trim().length) {
+    return true;
+  }
+  return false;
+};
+
+export const isValidURL = (link: string) => {
+  try {
+    const url = new URL(link);
+    return true;
+  } catch {
+    return false;
+  }
+};

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -1,0 +1,20 @@
+import { providers, supported_urls } from './constants.js';
+import { extractHostname, isEmpty, isValidURL } from './utils.js';
+
+class Validate {
+  check(link: string) {
+    if (isEmpty(link)) {
+      throw new Error('URL not provided!');
+    }
+
+    const isValid = isValidURL(link);
+    if (!isValid) {
+      throw new Error('Invlid URL!');
+    }
+
+    return true;
+  }
+}
+
+const validate = new Validate();
+export default validate;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,6 +26,6 @@
 
     /* AND if you're building for a library in a monorepo: */
     "declarationMap": true,
-    "lib": ["es2022"]
+    "lib": ["es2022", "DOM"]
   }
 }


### PR DESCRIPTION
## Summary
Added a feature to get the embed provider from a URL. Along with a test case for the same.
Supported URL: YouTube, Vimeo, Loom, Codepen, Codesandbox.